### PR TITLE
Fix detection of missing dark class pairs when multiple light classes share a property

### DIFF
--- a/src/rules/enforce-dark-mode-class-pairs.test.ts
+++ b/src/rules/enforce-dark-mode-class-pairs.test.ts
@@ -106,6 +106,20 @@ ruleTester.run('enforce-dark-mode-class-pairs', rule, {
       output:
         '<div className="text-neutral-900 bg-white dark:text-neutral-100 dark:bg-black" />',
     },
+    // Multiple light classes for the same property should each have dark variants
+    {
+      code: '<div className="text-neutral-900 text-white dark:text-neutral-100" />',
+      errors: [
+        {
+          messageId: 'missingDarkMode',
+          data: {
+            className: 'text-white',
+          },
+        },
+      ],
+      output:
+        '<div className="text-neutral-900 text-white dark:text-neutral-100 dark:text-black" />',
+    },
     // Template literal with missing dark variant - with proper mapping
     {
       code: 'const cls = `text-neutral-900`;',


### PR DESCRIPTION
## Summary
- count dark variants per property and ignore non-color classes when searching for missing dark mode pairs
- ensure rule matches each light class individually using those counts
- add regression test for multiple text classes

