### PR TITLE
docs: add pnpm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ npm install --save-dev eslint-plugin-tailwind-dark-mode
 yarn add -D eslint-plugin-tailwind-dark-mode
 ```
 
+### pnpm
+
+```bash
+pnpm add -D eslint-plugin-tailwind-dark-mode
+```
+
 ### Requirements
 
 - Node.js >= 18.0.0
@@ -52,7 +58,14 @@ yarn add -D eslint-plugin-tailwind-dark-mode
 ### Step 1: Install the plugin
 
 ```bash
+# npm
 npm install --save-dev eslint-plugin-tailwind-dark-mode
+
+# yarn
+yarn add -D eslint-plugin-tailwind-dark-mode
+
+# pnpm
+pnpm add -D eslint-plugin-tailwind-dark-mode
 ```
 
 ### Step 2: Configure ESLint


### PR DESCRIPTION
## Summary
- document pnpm install commands for the plugin
- show pnpm as an option in the quick start

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1461c3e048324a94733c7266f8c36